### PR TITLE
Update links where to look for destination_id and specification of source/destination connectors

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -59,12 +59,14 @@ resource "airbyte_connection" "custom" {
 
 # More complex E2E Testing setup with some custom configuration
 resource "airbyte_source" "e2e" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+  # Find the definition_id for an existing source here https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
   definition_id = "d53f9084-fa6b-4a5a-976c-5b8392f4ad8a"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_source"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "CONTINUOUS_FEED"
     mock_catalog = {
@@ -77,12 +79,14 @@ resource "airbyte_source" "e2e" {
 }
 
 resource "airbyte_destination" "e2e" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
   definition_id = "2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_destination"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "LOGGING"
     logging_config = {

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -37,12 +37,14 @@ resource "airbyte_destination" "test" {
 # More complex with existing destination definition
 # Uses E2E Testing Destination (https://docs.airbyte.com/integrations/destinations/e2e-test/)
 resource "airbyte_destination" "existing" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
   definition_id = "2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_destination"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "LOGGING"
     logging_config = {

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -37,12 +37,14 @@ resource "airbyte_source" "custom" {
 # More complex with existing source definition
 # Uses E2E Testing Source (https://docs.airbyte.com/integrations/sources/e2e-test/)
 resource "airbyte_source" "existing" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+  # Find the definition_id for an existing source here https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
   definition_id = "d53f9084-fa6b-4a5a-976c-5b8392f4ad8a"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_source"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "CONTINUOUS_FEED"
     mock_catalog = {

--- a/examples/resources/airbyte_connection/resource.tf
+++ b/examples/resources/airbyte_connection/resource.tf
@@ -44,12 +44,14 @@ resource "airbyte_connection" "custom" {
 
 # More complex E2E Testing setup with some custom configuration
 resource "airbyte_source" "e2e" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+  # Find the definition_id for an existing source here https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
   definition_id = "d53f9084-fa6b-4a5a-976c-5b8392f4ad8a"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_source"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "CONTINUOUS_FEED"
     mock_catalog = {
@@ -62,12 +64,14 @@ resource "airbyte_source" "e2e" {
 }
 
 resource "airbyte_destination" "e2e" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
   definition_id = "2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_destination"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "LOGGING"
     logging_config = {

--- a/examples/resources/airbyte_destination/resource.tf
+++ b/examples/resources/airbyte_destination/resource.tf
@@ -22,12 +22,14 @@ resource "airbyte_destination" "test" {
 # More complex with existing destination definition
 # Uses E2E Testing Destination (https://docs.airbyte.com/integrations/destinations/e2e-test/)
 resource "airbyte_destination" "existing" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
   definition_id = "2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_destination"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "LOGGING"
     logging_config = {

--- a/examples/resources/airbyte_source/resource.tf
+++ b/examples/resources/airbyte_source/resource.tf
@@ -22,12 +22,14 @@ resource "airbyte_source" "custom" {
 # More complex with existing source definition
 # Uses E2E Testing Source (https://docs.airbyte.com/integrations/sources/e2e-test/)
 resource "airbyte_source" "existing" {
-  # Find the definition_id for an existing source here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+  # Find the definition_id for an existing source here https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for metadata.yaml file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
   definition_id = "d53f9084-fa6b-4a5a-976c-5b8392f4ad8a"
   workspace_id  = airbyte_workspace.test.id
   name          = "e2e_source"
   # Find the spec either in the docs for the connector
-  # Or, find it here: https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+  # Or, find it here: https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors
+  # Look for src/main/resources/spec.json file, e.g. https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
   connection_configuration = jsonencode({
     type = "CONTINUOUS_FEED"
     mock_catalog = {


### PR DESCRIPTION
Hello @eabrouwer3 
I'm evaluating your provider for keeping Airbyte configuration in terraform. Thank you for your work!

I noticed that links:
https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/source_specs.yaml
https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
https://github.com/airbytehq/airbyte/blob/master/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
don't exist in `master` branch any more. I get `404 - page not found`.

I updated documentation where to look for destination_id and specification for the latest changes in [airbyte](https://github.com/airbytehq/airbyte) repository.